### PR TITLE
refactor: use unsafe retryable to have consistent behavior

### DIFF
--- a/src/contracts/arbitrum/CrosschainForwarderArbitrum.sol
+++ b/src/contracts/arbitrum/CrosschainForwarderArbitrum.sol
@@ -93,7 +93,7 @@ contract CrosschainForwarderArbitrum {
   function execute(address l2PayloadContract) public {
     bytes memory queue = getEncodedPayload(l2PayloadContract);
     uint256 maxSubmission = getRequiredGas(queue.length);
-    INBOX.createRetryableTicket{value: maxSubmission}(
+    INBOX.unsafeCreateRetryableTicket{value: maxSubmission}(
       ARBITRUM_BRIDGE_EXECUTOR,
       0, // l2CallValue
       maxSubmission, // maxSubmissionCost

--- a/src/test/arbitrum/ArbitrumStEth.t.sol
+++ b/src/test/arbitrum/ArbitrumStEth.t.sol
@@ -103,7 +103,7 @@ contract ArbitrumStEthE2ETest is ProtocolV3TestBase {
     vm.expectCall(
       address(INBOX),
       abi.encodeCall(
-        IInbox.createRetryableTicket,
+        IInbox.unsafeCreateRetryableTicket,
         (
           ARBITRUM_BRIDGE_EXECUTOR,
           0,


### PR DESCRIPTION
`createRetryableTicket` applies an alias on `excessFeeRefundAddress` & `callValueRefundAddress` in case there is code on l1 on these addresses. While currently there isn't, there might be at some point.